### PR TITLE
Updating dependency firebase/php-jwt from ^5.2 to ^6.0 to include sec…

### DIFF
--- a/Helper/Crypto.php
+++ b/Helper/Crypto.php
@@ -3,6 +3,7 @@
 namespace Pledg\PledgPaymentGateway\Helper;
 
 use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
 
 class Crypto
 {
@@ -25,6 +26,6 @@ class Crypto
      */
     public function decode(string $signature, string $secretKey): array
     {
-        return (array)JWT::decode($signature, $secretKey, ['HS256']);
+        return (array)JWT::decode($signature,new Key($secretKey, 'HS256'));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Pledg Payment Gateway",
     "require": {
         "php": "~7.1.3||~7.2.0||~7.3.0||~7.4||~8.1",
-        "firebase/php-jwt": "^5.2",
+        "firebase/php-jwt": "^6.0",
         "ext-json": "*",
         "ext-iconv": "*"
     },


### PR DESCRIPTION
…urity fixes and allow compatibility with Magento 2.4.6 that require firebase/php-jwt ^6.0 for module magento/module-quick-checkout .